### PR TITLE
Added RGB procedures for background and foreground

### DIFF
--- a/src/rainbow.nim
+++ b/src/rainbow.nim
@@ -18,6 +18,11 @@
 #Reset procedure 
 proc reset(): string = "\e[0m"
 
+#RGB procedures
+proc fgRGB*(s:string, r:Natural, g:Natural, b:Natural): string = "\e[38;2;" & $r & ";" & $g & ";" & $b & "m" & s & reset()
+
+proc bgRGB*(s:string, r:Natural, g:Natural, b:Natural): string = "\e[48;2;" & $r & ";" & $g & ";" & $b & "m" & s & reset()
+
 #Rainbow 256 Foreground Colors
 proc rfBlack*(s: string): string = "\e[38;5;0m" & s & reset()
 proc rfMaroon*(s: string): string = "\e[38;5;1m" & s & reset()


### PR DESCRIPTION
## Description
Added some procedures letting the user create custom color using RGB values.

## Example:
```nim
"Hello world".fgRGB(0,0,255) # Put "Hello world" in blue
"Hello world".bgRGB(0,0,255) # Put "Hello world" background in blue
```
## Notes
Values can go from `0` (Black) to `255` (Lightest). Higher values will result in none colored output 

On windows OS the `VirtualTerminalLevel` register key need to be set to `1` in `HKCU\Console` as a `D_WORD`
Use that command to add it permanantly `reg add HKCU\Console /v VirtualTerminalLevel /t REG_DWORD /d 00000001`
